### PR TITLE
Fix calculation error in weightedEuclideanDistance comparator function

### DIFF
--- a/src/Comparators.hs
+++ b/src/Comparators.hs
@@ -21,7 +21,7 @@ weightedEuclideanDistance :: DistanceFunction
 weightedEuclideanDistance a b = do
     let r = (r1 + r2) / 2
             where r1 = fromIntegral $ head a :: Float
-                  r2 = fromIntegral $ head a :: Float
+                  r2 = fromIntegral $ head b :: Float
     let weightG = 4.0
     let weightR = 2 + r / 256
     let weightB = 2 + ((255 - r) / 256)


### PR DESCRIPTION
Variable r2 was gettings its value from the first RGB list (a) whereas it should've been getting its value from the second RGB list (b).