### PR TITLE
Add flag to allow comparison to a JSON file

### DIFF
--- a/color-comparator.cabal
+++ b/color-comparator.cabal
@@ -27,6 +27,8 @@ library
         aeson ^>=1.5.6.0,
         bytestring ^>=0.10.12.0,
         containers ^>=0.6.5.1,
+        optparse-applicative ^>=0.16.1,
+        regex-tdfa ^>=1.3.1
     default-language: Haskell2010
 
 executable color-comparator
@@ -42,6 +44,8 @@ executable color-comparator
         aeson ^>=1.5.6.0,
         bytestring ^>=0.10.12.0,
         containers ^>=0.6.5.1,
+        optparse-applicative ^>=0.16.1,
+        regex-tdfa ^>=1.3.1
     other-modules:
         Colors
         Comparators

--- a/src/Comparators.hs
+++ b/src/Comparators.hs
@@ -1,8 +1,10 @@
 module Comparators 
     ( euclideanDistance
     , weightedEuclideanDistance
-    , DistanceFunction
+    , ComparatorFunction
     ) where
+
+import Colors (RGB (..), rgbToList)
 
 -- Helpers
 square :: Int -> Int
@@ -10,21 +12,25 @@ square x = x * x
 
 -- Comparators
 -- NOTE: [Int] -> [Int] -> Float represents [r,g,b] -> [r,g,b] -> distance
-type DistanceFunction = [Int] -> [Int] -> Float
+type ComparatorFunction = RGB -> RGB -> Float
 
-euclideanDistance :: DistanceFunction
-euclideanDistance a b = sqrt . fromIntegral $ sum $ map square $ zipWith (-) a b
+euclideanDistance :: ComparatorFunction
+euclideanDistance a b = sqrt . fromIntegral $ sum $ map square $ zipWith (-) a' b'
+    where a' = rgbToList a
+          b' = rgbToList b
 
 -- Low-cost approximation of Euclidean Distance
 -- Taken from https://www.compuphase.com/cmetric.htm
-weightedEuclideanDistance :: DistanceFunction
+weightedEuclideanDistance :: ComparatorFunction
 weightedEuclideanDistance a b = do
-    let r = (r1 + r2) / 2
-            where r1 = fromIntegral $ head a :: Float
-                  r2 = fromIntegral $ head b :: Float
+    let rmean = (r1 + r2) / 2
+            where r1 = fromIntegral $ r a
+                  r2 = fromIntegral $ r b
     let weightG = 4.0
-    let weightR = 2 + r / 256
-    let weightB = 2 + ((255 - r) / 256)
+    let weightR = 2 + rmean / 256
+    let weightB = 2 + ((255 - rmean) / 256)
     sqrt $ weightR * fromIntegral (head dist) + weightG * fromIntegral (dist !! 1) + weightB * fromIntegral (last dist)
-            where dist = map square $ zipWith (-) a b
+            where dist = map square $ zipWith (-) a' b'
+                    where a' = rgbToList a
+                          b' = rgbToList b
 

--- a/src/ResultBuilder.hs
+++ b/src/ResultBuilder.hs
@@ -5,9 +5,17 @@ module ResultBuilder
     , displayTerm256Color
     , displayRgbColor
     , buildResult
+    , printResult
     ) where
 
 import Text.Printf
+import Data.Map ((!))
+import Data.Maybe (fromMaybe)
+
+import Colors (RGB(..), rgbToList, IdMap)
+
+notTermID :: Int
+notTermID = -1
 
 term256EscStr :: String
 term256EscStr = "\ESC[38;5;%dm███████\ESC[0m "
@@ -18,26 +26,32 @@ termRgbEscStr = "\ESC[38;2;%d;%d;%dm███████\ESC[0m "
 -- Result is the base result output returned. Additional outputs can be appended/prepended
 -- to the Result output string.
 data Result = Result
-              { resultHex :: String
-              , resultRgb :: [Int]
-              , resultDistance :: Float
+              { hexString :: String
+              , rgb :: RGB
+              , distance :: Float
               } deriving (Show)
 
 resultToString :: Result -> String
-resultToString result = printf "%s %s %s" hex rgb distance
+resultToString result = printf "%s %s %s" hexString' rgb' distance'
     where
-        hex = resultHex result
-        rgb = show $ resultRgb result
-        distance = show $ resultDistance result
+        hexString' = hexString result
+        rgb' = show $ rgbToList $ rgb result
+        distance' = show $ distance result
 
 displayTerm256Color :: Int -> String
 displayTerm256Color = printf term256EscStr
 
-displayRgbColor :: [Int] -> String
-displayRgbColor rgb = printf termRgbEscStr r g b
-    where r = head rgb
-          g = rgb !! 1
-          b = rgb !! 2
+displayRgbColor :: RGB -> String
+displayRgbColor rgb = printf termRgbEscStr (r rgb) (g rgb) (b rgb)
 
 buildResult :: String -> [String]-> String
 buildResult r s = unwords s ++ " " ++ r ++ "\n"
+
+printResult :: Result -> Maybe IdMap -> IO ()
+printResult r (Just idMap) = putStr $ buildResult (resultToString r) [ displayColor, termID ]
+    where
+        displayColor = if id == notTermID then "" else displayTerm256Color id
+        termID = if id == notTermID then "" else show id
+        id = fromMaybe notTermID (idMap ! hexString r)
+
+printResult r Nothing = putStr $ buildResult (resultToString r) [ displayRgbColor $ (rgb :: Result -> RGB) r ]


### PR DESCRIPTION
This PR adds a `--file` flag to the CLI arguments to allow comparison of a hex color string to a JSON file of colors. The format of the JSON file is based off of the `term_256_colors.json` file.

New additional changes includes:
* CLI parsing using `optparse-applicative`
  * This will be the CLI library used going forward for future CLI features
* `Color` record type is restructured to `Term256Color` record's with `Maybe` types for optional fields
  * `Term256Color` record struct is removed.
  * This was done to keep consistency between different file inputs and makes it easier to maintain.

Resolves issue #7 