### PR TITLE
Add option to pass a string-list of hex colors for comparison

### DIFF
--- a/color-comparator.cabal
+++ b/color-comparator.cabal
@@ -28,7 +28,8 @@ library
         bytestring ^>=0.10.12.0,
         containers ^>=0.6.5.1,
         optparse-applicative ^>=0.16.1,
-        regex-tdfa ^>=1.3.1
+        regex-tdfa ^>=1.3.1,
+        split ^>=0.2.3.4
     default-language: Haskell2010
 
 executable color-comparator
@@ -45,7 +46,8 @@ executable color-comparator
         bytestring ^>=0.10.12.0,
         containers ^>=0.6.5.1,
         optparse-applicative ^>=0.16.1,
-        regex-tdfa ^>=1.3.1
+        regex-tdfa ^>=1.3.1,
+        split ^>=0.2.3.4
     other-modules:
         Colors
         Comparators

--- a/src/ResultBuilder.hs
+++ b/src/ResultBuilder.hs
@@ -57,5 +57,5 @@ printResult :: Result -> IdMap -> IO ()
 printResult r idMap = putStr $ buildOutput (resultToString r) (displayColor : [ termID ])
     where
         displayColor = maybe (displayRgbColor $ rgb r) displayTerm256Color id
-        termID = maybe "" show id
+        termID = maybe " " show id
         id = Map.lookup (hexString r) idMap


### PR DESCRIPTION
New feature to allow passing of a list of hex color strings in string format, i.e `" #<color>, #<color>, ...`.

This option can be used alongside `--file/-f`, however, the resulting comparisons are separate.

Closes #6 