### PR TITLE
Fix term256 comparison is always on

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -98,7 +98,7 @@ app opts = do
 
     when (isJust (inputColors opts)) $ runWithStr inputHex c >>= printOutput
     when (isJust (optFile opts)) $ runWithFile inputHex f >>= printOutput
-    when (isJust (term256 opts)) $ runWithFile inputHex term256ColorsJSON >>= printOutput
+    when (useTerm256 opts) $ runWithFile inputHex term256ColorsJSON >>= printOutput
         where
             f = fromMaybe "" (optFile opts)
             c = fromMaybe "" (inputColors opts)
@@ -107,14 +107,14 @@ data Opts = Opts
             { inputColor :: String
             , inputColors :: Maybe String
             , optFile :: Maybe String
-            , term256 :: Maybe Bool
+            , useTerm256 :: Bool
             } deriving (Show)
 optsParser :: Parser Opts
 optsParser = Opts
         <$> strArgument ( metavar "HEX_COLOR" <> help "Input hex color string")
         <*> optional ( strArgument $ metavar "HEX_COLORS" <> help "Input hex color strings to compare to")
         <*> optional ( strOption $ long "file" <> short 'f' <> metavar "COLOR FILE" <> help "File of colors to compare to")
-        <*> optional ( switch $ long "term256" <> help "File of colors to compare to")
+        <*> switch ( long "term256" <> help "File of colors to compare to")
 
 
 main :: IO ()


### PR DESCRIPTION
#17 (a1b3d3341b377d9f5c46bfe945a6dcd76cc41b26) introduced `--term256` as an toggle-able option, but this was always ran even without the option specified.

Switching from `Maybe Bool` -> `Bool` for the option fixes this as the flag is defaulted to `false` if not present.