### PR TITLE
Add option to chose how many results per comparison source to return

### DIFF
--- a/src/Colors.hs
+++ b/src/Colors.hs
@@ -112,6 +112,6 @@ hexToRGB = rgbListToRGB . hexToRgbList . removeHexHash . validateInputHexColor
 validateInputHexColor :: String -> String
 validateInputHexColor s
     | isHexColor = s
-    | otherwise = error errInvalidInput
+    | otherwise = error $ errInvalidInput ++ " " ++  s
     where
         isHexColor = s =~ hexColorRegex :: Bool

--- a/src/ResultBuilder.hs
+++ b/src/ResultBuilder.hs
@@ -31,10 +31,10 @@ data ResultAddOns = ResultAddOns
                     }
 
 resultToStr :: Result -> String
-resultToStr result = printf "%s %s %.2f" hexString' rgb' distance'
+resultToStr result = printf " %s  %s  %.2f" hexString' rgb' distance'
     where
         hexString' = addHexHash . hexString $ color result
-        rgb' = printf "(%3d,%3d,%3d)" (r rgbs) (g rgbs) (b rgbs) :: String
+        rgb' = printf "(%3d, %3d, %3d)" (r rgbs) (g rgbs) (b rgbs) :: String
         rgbs = rgb $ color result
         distance' = distance result
 


### PR DESCRIPTION
Ex:
```
$ color-comparator  "#000fff" "000123, #123256, fafafa, #21feab,890221" --term256 -n 4
Up to date
███████      #000fff  (  0,  15, 255)  0.00
Results: 
███████      #123256  ( 18,  50,  86)  300.21
███████      #000123  (  0,   1,  35)  381.83
███████      #890221  (137,   2,  33)  421.55
███████      #21feab  ( 33, 254, 171)  501.42
Results: 
███████  12  #0000ff  (  0,   0, 255)  30.00
███████  21  #0000ff  (  0,   0, 255)  30.00
███████  20  #0000d7  (  0,   0, 215)  75.46
███████  19  #0000af  (  0,   0, 175)  141.69
```


Closes #20 