### PR TITLE
Refactor to slim down setup and processing

### DIFF
--- a/src/Colors.hs
+++ b/src/Colors.hs
@@ -5,7 +5,6 @@
 module Colors
     ( Color (..)
     , RGB (..)
-    , loadColorsFile
     , rgbToList
     , addHexHash
     , removeHexHash
@@ -16,15 +15,9 @@ module Colors
     , validateFromHexColor
     ) where
 import GHC.Generics
-import Data.Aeson
-import Data.Aeson.TH
-import qualified Data.ByteString.Lazy as B
-
-import Text.Regex.TDFA
-
-import Data.Maybe (isJust, fromJust)
-
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Char (isHexDigit, digitToInt, toLower)
+import Text.Regex.TDFA
 
 errInvalidHexColorString :: String
 errInvalidHexColorString = "Invalid color hex string passed"
@@ -41,9 +34,6 @@ removeHexHash :: String -> String
 removeHexHash h
     | head h == '#' = tail h
     | otherwise = h
-
-loadColorsFile :: String -> IO (Either String [Color])
-loadColorsFile f = eitherDecode <$> B.readFile f
 
 data RGB = RGB
            { r :: Int

--- a/src/ResultBuilder.hs
+++ b/src/ResultBuilder.hs
@@ -4,11 +4,10 @@ module ResultBuilder
     , resultToStr
     , displayRgbColor
     , buildOutput
-    , printOutput
+    , printResult
     ) where
 
 import Text.Printf
-import Data.Maybe (fromMaybe)
 
 import Colors (Color(..), RGB(..), addHexHash)
 
@@ -45,8 +44,8 @@ buildOutput r a = tc ++ id ++ " " ++ rs ++ "\n"
         tc = xtermDisplayColor a
         id = printf "%3s" (xtermId a)
 
-printOutput :: Result -> IO ()
-printOutput r = putStr $ buildOutput r (ResultAddOns displayColor id)
+printResult :: Result -> IO ()
+printResult r = putStr $ buildOutput r (ResultAddOns displayColor id)
     where
         displayColor = displayRgbColor . rgb $ color r
         id = maybe "" show . colorId $ color r


### PR DESCRIPTION
This is down to remove the excess redundant functions (such as `runWithStr`, `runWithFile`) and decouple some functions.